### PR TITLE
`feat`: add `config` command

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -68,4 +68,14 @@ config
     console.log("Username updated.");
   });
 
+config
+  .command("token")
+  .argument("<token>", "GitHub personal access token")
+  .description("Set GitHub personal access token")
+  .action((token) => {
+    const config = loadConfig();
+    saveConfig({ ...config, token });
+    console.log("Token updated.");
+  });
+
 program.parse();

--- a/main.ts
+++ b/main.ts
@@ -6,31 +6,28 @@ import ok from "./octokit.js";
 const program = new Command();
 program.name("gitty").description("GitHub CLI tool").version("1.0.0");
 
-const auth = program.command("auth").description("Authentication and setup");
+const setup = program.command("setup").description("Setup gitty");
 
-auth
-  .command("setup")
-  .description("Configure your gitty settings")
-  .action(async () => {
-    const config = loadConfig();
+setup.action(async () => {
+  const config = loadConfig();
 
-    let username = await input({ message: "Enter your GitHub username:" });
-    const confirmed = await confirm({
-      message: `Username is ${username}, confirm?`,
-    });
-
-    if (!confirmed) {
-      username = await input({ message: "Enter your GitHub username:" });
-    }
-    saveConfig({ ...config, username });
-
-    const token = await password({
-      message: "Enter your GitHub personal access token:",
-    });
-    saveConfig({ ...config, token });
-
-    console.log("Setup complete.");
+  let username = await input({ message: "Enter your GitHub username:" });
+  const confirmed = await confirm({
+    message: `Username is ${username}, confirm?`,
   });
+
+  if (!confirmed) {
+    username = await input({ message: "Enter your GitHub username:" });
+  }
+  saveConfig({ ...config, username });
+
+  const token = await password({
+    message: "Enter your GitHub personal access token:",
+  });
+  saveConfig({ ...config, token });
+
+  console.log("Setup complete.");
+});
 
 const repo = program.command("repo").description("Repository commands");
 

--- a/main.ts
+++ b/main.ts
@@ -58,4 +58,14 @@ config
     console.log(`Token: ${config.token}`);
   });
 
+config
+  .command("username")
+  .argument("<username>", "GitHub username")
+  .description("Set GitHub username")
+  .action((username) => {
+    const config = loadConfig();
+    saveConfig({ ...config, username });
+    console.log("Username updated.");
+  });
+
 program.parse();

--- a/main.ts
+++ b/main.ts
@@ -47,4 +47,15 @@ repo
     response.data.forEach(({ name }: { name: string }) => console.log(name));
   });
 
+const config = program.command("config").description("Configuration commands");
+config
+  .command("--list")
+  .description("Show current configuration")
+  .action(() => {
+    const config = loadConfig();
+    console.log("Current configuration:");
+    console.log(`Username: ${config.username}`);
+    console.log(`Token: ${config.token}`);
+  });
+
 program.parse();


### PR DESCRIPTION
# Changes in this PR 

This PR is raised to add the `config` command & clean up the `gitty auth setup` command.

## Addition of `config` command

The `config` command was added & supports the following sub-commands:
- `gitty config --list` - lists the current gitty config
- `gitty config username <username>` - sets the GitHub username in `gitty`
- `gitty config token <token>` - sets the GitHub personal access token in `gitty`

## Clean up of `gitty auth setup` command 

The `gitty auth setup` command has been refactored to `gitty setup` & is meant to serve as a one-time setup command for users to set up `gitty` correctly.
