### PR TITLE
`chore`: cleanup the `config` command

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -5,6 +5,7 @@ import ok from "./octokit.js";
 
 const program = new Command();
 program.name("gitty").description("GitHub CLI tool").version("1.0.0");
+program.configureHelp({ sortSubcommands: true });
 
 const setup = program.command("setup").description("Setup gitty");
 

--- a/main.ts
+++ b/main.ts
@@ -49,15 +49,14 @@ repo
   });
 
 const config = program.command("config").description("Configuration commands");
-config
-  .command("--list")
-  .description("Show current configuration")
-  .action(() => {
-    const config = loadConfig();
-    console.log("Current configuration:");
-    console.log(`Username: ${config.username}`);
-    console.log(`Token: ${config.token}`);
-  });
+config.option("--list", "Show current configuration");
+
+if (config.opts().list) {
+  const cfg = loadConfig();
+  console.log("Current configuration:");
+  console.log(`\tUsername: ${cfg.username}`);
+  console.log(`\tToken: ${cfg.token}`);
+}
 
 config
   .command("username")

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,21 +1,20 @@
 {
-  "name": "gitty",
+  "name": "@waffledood/gitty",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "gitty",
+      "name": "@waffledood/gitty",
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
         "@inquirer/prompts": "^8.4.2",
         "commander": "^14.0.3",
-        "dotenv": "^17.4.2",
         "octokit": "^5.0.5"
       },
       "bin": {
-        "gitty": "bin/gitty.mjs"
+        "gitty": "dist/gitty.cjs"
       },
       "devDependencies": {
         "esbuild": "^0.28.0",
@@ -1307,18 +1306,6 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
-      }
-    },
-    "node_modules/dotenv": {
-      "version": "17.4.2",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
-      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://dotenvx.com"
       }
     },
     "node_modules/esbuild": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
   "dependencies": {
     "@inquirer/prompts": "^8.4.2",
     "commander": "^14.0.3",
-    "dotenv": "^17.4.2",
     "octokit": "^5.0.5"
   }
 }


### PR DESCRIPTION
# Changes in this PR 

This PR is raised for the following changes:

- Cleanup the `config` command:
  - Refactor `--list` to be an option, instead of a sub-command of `config` 