### PR TITLE
`chore`: sort help subcommands alphabetically

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -5,6 +5,7 @@ import ok from "./octokit.js";
 
 const program = new Command();
 program.name("gitty").description("GitHub CLI tool").version("1.0.0");
+program.configureHelp({ sortSubcommands: true });
 
 const setup = program.command("setup").description("Setup gitty");
 


### PR DESCRIPTION
# Changes in this PR 

This PR is raised to sort the help subcommands alphabetically.

Currently the commands are ordered in the order they were defined programmatically in the code:

```shell
$ gitty
Usage: gitty [options] [command]

GitHub CLI tool

Options:
  -V, --version   output the version number
  -h, --help      display help for command

Commands:
  setup           Setup gitty
  repo            Repository commands
  config          Configuration commands
  help [command]  display help for command
```