### PR TITLE
`refactor`: change --list to be an option instead of command

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -48,15 +48,14 @@ repo
   });
 
 const config = program.command("config").description("Configuration commands");
-config
-  .command("--list")
-  .description("Show current configuration")
-  .action(() => {
-    const config = loadConfig();
-    console.log("Current configuration:");
-    console.log(`Username: ${config.username}`);
-    console.log(`Token: ${config.token}`);
-  });
+config.option("--list", "Show current configuration");
+
+if (config.opts().list) {
+  const cfg = loadConfig();
+  console.log("Current configuration:");
+  console.log(`\tUsername: ${cfg.username}`);
+  console.log(`\tToken: ${cfg.token}`);
+}
 
 config
   .command("username")


### PR DESCRIPTION
# Changes in this PR 

This PR is raised to refactor the `--list` command to be an `option` instead.

```shell
$ gitty
Usage: gitty config [options] [command]

Configuration commands

Options:
  -h, --help           display help for command

Commands:
  --list               Show current configuration
  username <username>  Set GitHub username
  token <token>        Set GitHub personal access token
  help [command]       display help for command
```