### PR TITLE
chore: update Node.js version to 22 in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
 
       - name: Install dependencies


### PR DESCRIPTION
## Summary

- Fixes the `.github/workflows/release.yml` GitHub Actions workflow due to [this error](https://github.com/waffledood/gitty/actions/runs/25322089767). 