### PR TITLE
`fix`: improve config command to handle list option and display current configuration

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -49,14 +49,17 @@ repo
   });
 
 const config = program.command("config").description("Configuration commands");
-config.option("--list", "Show current configuration");
-
-if (config.opts().list) {
-  const cfg = loadConfig();
-  console.log("Current configuration:");
-  console.log(`\tUsername: ${cfg.username}`);
-  console.log(`\tToken: ${cfg.token}`);
-}
+config.option("-l, --list", "Show current configuration");
+config.action((options) => {
+  if (options.list) {
+    const cfg = loadConfig();
+    console.log("Current configuration:");
+    console.log(`Username: ${cfg.username}`);
+    console.log(`Token: ${cfg.token}`);
+  } else {
+    config.help();
+  }
+});
 
 config
   .command("username")


### PR DESCRIPTION
## Summary

- Fixes the buggy `config --list` / `gitty config -l` command that wasn't returning the user's config